### PR TITLE
Check for existence of 'window' using typeof

### DIFF
--- a/lodash.math.js
+++ b/lodash.math.js
@@ -1,8 +1,11 @@
 (function () {
   
   function mixin_loader(lodash) {
-    var math = this.math = {};
-    if(lodash === undefined) {    
+    var math = {};
+    if(this) {
+      this.math = math;
+    }
+    if(!lodash) {    
       lodash = require('lodash').runInContext();
     }
    
@@ -329,7 +332,7 @@
     return lodash;
   }
 
-  if(window !== undefined) {
+  if(typeof window !== 'undefined') {
     mixin_loader(_);
   }
   else {


### PR DESCRIPTION
Hi! I was having some trouble using this library in strict-mode node. Had to make two changes:
- Check for the existence of the global `window` with `typeof window === 'undefined'`
- For top-level functions in node, `this` is undefined. I wrapped the assignment of `this.math`.
